### PR TITLE
Configure individual pad audio routing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2644,66 +2644,7 @@ function SettingsModal({ settings, scene, onUpdateSettings, onUpdatePadRoute, on
             </div>
           </div>
 
-          <div style={{ margin: "16px 0", color: "#bbb" }}>Per-Pad Routing (Current Scene)</div>
-          <div className="rowFlex">
-            <div className="field" style={{ flex: 1 }}>
-              <label>Background</label>
-              {(scene?.background || []).map((p) => (
-                <div key={p.id} className="rowFlex" style={{ gap: 6, marginBottom: 6 }}>
-                  <div style={{ width: 140, color: "#ddd" }}>{p.label || p.name}</div>
-                  <select
-                    style={{ flex: 1 }}
-                    value={p.routeKey || "master"}
-                    onChange={(e) => onUpdatePadRoute?.("background", p.id, e.target.value)}
-                  >
-                    {outputs.map((o) => (
-                      <option key={o.key} value={o.key}>
-                        {o.label}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-              ))}
-            </div>
-            <div className="field" style={{ flex: 1 }}>
-              <label>Ambient</label>
-              {(scene?.ambients || []).map((p) => (
-                <div key={p.id} className="rowFlex" style={{ gap: 6, marginBottom: 6 }}>
-                  <div style={{ width: 140, color: "#ddd" }}>{p.label || p.name}</div>
-                  <select
-                    style={{ flex: 1 }}
-                    value={p.routeKey || "master"}
-                    onChange={(e) => onUpdatePadRoute?.("ambients", p.id, e.target.value)}
-                  >
-                    {outputs.map((o) => (
-                      <option key={o.key} value={o.key}>
-                        {o.label}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-              ))}
-            </div>
-            <div className="field" style={{ flex: 1 }}>
-              <label>SFX</label>
-              {(scene?.sfx || []).map((p) => (
-                <div key={p.id} className="rowFlex" style={{ gap: 6, marginBottom: 6 }}>
-                  <div style={{ width: 140, color: "#ddd" }}>{p.label || p.name}</div>
-                  <select
-                    style={{ flex: 1 }}
-                    value={p.routeKey || "master"}
-                    onChange={(e) => onUpdatePadRoute?.("sfx", p.id, e.target.value)}
-                  >
-                    {outputs.map((o) => (
-                      <option key={o.key} value={o.key}>
-                        {o.label}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-              ))}
-            </div>
-          </div>
+          {/* Per-Pad Routing removed: moved to per-pad editor to reduce clutter */}
           {/* Audio Test Player removed per UI cleanup */}
           <div style={{ margin: "16px 0", color: "#bbb" }}>MIDI (Web MIDI)</div>
           <div className="rowFlex">


### PR DESCRIPTION
Remove per-pad audio routing from the main settings page.

This change reduces clutter on the main settings page, as per-pad routing controls will now be moved to the individual pad editing page.

---
<a href="https://cursor.com/background-agent?bcId=bc-628b690e-04be-4351-9610-9f107790f894">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-628b690e-04be-4351-9610-9f107790f894">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

